### PR TITLE
Fix Windows path conversion in run.ps1

### DIFF
--- a/run.ps1
+++ b/run.ps1
@@ -27,7 +27,7 @@
 # $logPath = (Resolve-Path "$PSScriptRoot\logs").Path
 
 $windowsLogPath = (Resolve-Path "$PSScriptRoot\logs").Path
-$logPath = $windowsLogPath -replace '\\', '/' -replace '^([A-Za-z]):', { "/mnt/$($args[0].ToLower())" }
+$logPath = $windowsLogPath -replace '\\', '/' -replace '^([A-Za-z]):', { "/mnt/$($matches[1].ToLower())" }
 
 
 # ------------------------------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- fix Windows-to-WSL path conversion by using `$matches[1]`

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ac59acfe74832881e7b62a385b79d1